### PR TITLE
fix: Remove unused user roles

### DIFF
--- a/cypress/fixtures/api.v1.login.json
+++ b/cypress/fixtures/api.v1.login.json
@@ -20,7 +20,6 @@
 			"status": "offline",
 			"active": true,
 			"_updatedAt": "2020-11-24T14:00:59.026Z",
-			"roles": ["user"],
 			"customFields": {},
 			"statusConnection": "offline",
 			"avatarUrl": "http://caritas/avatarUrl",

--- a/cypress/fixtures/service.users.data.askers.json
+++ b/cypress/fixtures/service.users.data.askers.json
@@ -6,7 +6,6 @@
 	"email": null,
 	"absenceMessage": null,
 	"agencies": null,
-	"userRoles": ["offline_access", "uma_authorization", "user"],
 	"grantedAuthorities": ["AUTHORIZATION_USER_DEFAULT"],
 	"consultingTypes": {
 		"0": { "sessionData": null, "isRegistered": false, "agency": null },

--- a/cypress/fixtures/service.users.data.consultants.json
+++ b/cypress/fixtures/service.users.data.consultants.json
@@ -17,7 +17,6 @@
 			"consultingType": 0
 		}
 	],
-	"userRoles": ["consultant"],
 	"grantedAuthorities": ["AUTHORIZATION_CONSULTANT_DEFAULT"],
 	"consultingTypes": null,
 	"formalLanguage": true,

--- a/src/generated/userservice.d.ts
+++ b/src/generated/userservice.d.ts
@@ -563,7 +563,6 @@ declare namespace UserService {
 			 */
 			isInTeamAgency?: boolean;
 			agencies?: AgencyDTO[];
-			userRoles?: string[];
 			grantedAuthorities?: string[];
 			consultingTypes?: ConsultingTypeMap;
 		}

--- a/src/globalState/globalState_notes.md
+++ b/src/globalState/globalState_notes.md
@@ -21,7 +21,6 @@
 			"teamAgency": false
 		}
 	],
-	"userRoles": ["string"],
 	"grantedAuthorities": ["string"]
 }
 ```

--- a/src/globalState/helpers/stateHelpers.ts
+++ b/src/globalState/helpers/stateHelpers.ts
@@ -11,19 +11,6 @@ import {
 } from '../../components/session/sessionHelpers';
 import { translate } from '../../resources/scripts/i18n/translate';
 
-export const USER_ROLES = {
-	USER: 'user',
-	CONSULTANT: 'consultant',
-	U25_CONSULTANT: 'u25-consultant',
-	U25_MAIN_CONSULTANT: 'u25-main-consultant',
-	KREUZBUND_CONSULTANT: 'kreuzbund-consultant'
-};
-
-export const isUserRole = (
-	role: string,
-	userData: UserDataInterface
-): boolean => userData.userRoles.includes(role);
-
 export const ACTIVE_SESSION = {
 	CREATE_CHAT: 'CREATE_CHAT'
 };

--- a/src/globalState/interfaces/UserDataInterface.ts
+++ b/src/globalState/interfaces/UserDataInterface.ts
@@ -13,7 +13,6 @@ export interface UserDataInterface {
 	lastName?: string;
 	userId: string;
 	userName: string;
-	userRoles: [string];
 }
 
 export interface AgencyDataInterface {


### PR DESCRIPTION
There are three places where user roles are still referenced, however they're only in mock data:
1. `api.v1.login.json`
2. `service.users.data.askers.json`
3. `service.users.data.consultants.json`

Since I guess these reflect the actual responses from backend services, I left them in place for now. We won't be able to use them, since we've removed the properties from the interfaces. Let me know however, if you'd like to have them removed from the fixtures as well!